### PR TITLE
CANS-721: Adding generic webhook trigger properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,13 @@ sourceSets {
   test.groovy.srcDirs = ['test/']
 }
 
+test {
+  testLogging {
+    exceptionFormat = 'full'
+    events "PASSED", "STARTED", "FAILED", "SKIPPED"
+  }
+}
+
 repositories {
   // Spock releases are available from Maven Central
   mavenCentral()

--- a/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
+++ b/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
@@ -19,7 +19,7 @@ class PullRequestMergedTrigger {
       ],
       regexpFilterText: '$pull_request_action:$trigger_key:$pull_request_merged',
       regexpFilterExpression: '^closed:' + triggerKeyParameter + ':true$',
-      causeString: 'Triggered by PR merge test',
+      causeString: 'Triggered by PR merge',
       printContributedVariables: false
     ]
   }

--- a/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
+++ b/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
@@ -1,0 +1,26 @@
+package gov.ca.cwds.jenkins
+
+class PullRequestMergedTrigger {
+  def script
+
+  PullRequestMergedTrigger(script) {
+    this.script = script
+  }
+
+  def triggerProperties(triggerKeyParameter) {
+    [$class: 'GenericTrigger',
+      genericVariables: [
+        [key: 'pull_request_action', value: 'action'],
+        [key: 'pull_request_merged', value: 'pull_request.merged'],
+        [key: 'pull_request_event', value: 'pull_request']
+      ],
+      genericRequestVariables: [
+        [key: 'trigger_key']
+      ],
+      regexpFilterText: '$pull_request_action:$trigger_key:$pull_request_merged',
+      regexpFilterExpression: '^closed:' + triggerKeyParameter + ':true$',
+      causeString: 'Triggered by PR merge',
+      printContributedVariables: false
+    ]
+  }
+}

--- a/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
+++ b/src/gov/ca/cwds/jenkins/PullRequestMergedTrigger.groovy
@@ -19,7 +19,7 @@ class PullRequestMergedTrigger {
       ],
       regexpFilterText: '$pull_request_action:$trigger_key:$pull_request_merged',
       regexpFilterExpression: '^closed:' + triggerKeyParameter + ':true$',
-      causeString: 'Triggered by PR merge',
+      causeString: 'Triggered by PR merge test',
       printContributedVariables: false
     ]
   }

--- a/test/gov/ca/cwds/jenkins/PullRequestMergedTriggerSpecification.groovy
+++ b/test/gov/ca/cwds/jenkins/PullRequestMergedTriggerSpecification.groovy
@@ -1,0 +1,25 @@
+package gov.ca.cwds.jenkins
+
+import spock.lang.Specification
+
+class PullRequestMergedTriggerSpecification extends Specification {
+  class PipeLineScript {
+    def build(hash) {
+    }
+
+    def PipeLineScript() { }
+  }
+
+  def "#triggerProperties returns a map with a regex based on trigger key"() {
+    given:
+    def pipeline = Mock(PipeLineScript)
+    def pullRequestMergedTrigger = new PullRequestMergedTrigger(pipeline)
+
+    when:
+    def properties = pullRequestMergedTrigger.triggerProperties("triggerKeyParameter")
+
+    then:
+    properties['$class'] == 'GenericTrigger'
+    properties['regexpFilterExpression'] == '^closed:triggerKeyParameter:true$'
+  }
+}

--- a/vars/pullRequestMergedTriggerProperties.groovy
+++ b/vars/pullRequestMergedTriggerProperties.groovy
@@ -1,0 +1,7 @@
+#!/usr/bin/env groovy
+import gov.ca.cwds.jenkins.PullRequestMergedTrigger
+
+def call(String triggerKeyParameter) {
+  pullRequestMergedTrigger = new PullRequestMergedTrigger(this)
+  pullRequestMergedTrigger.triggerProperties(triggerKeyParameter)
+}


### PR DESCRIPTION
This just moves this hairy config into a shared library so it can
be contained in every master build project going forward.  You can
run the tests by a `gradle test`