### PR TITLE
Creates a new workspace for updating manifest file

### DIFF
--- a/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
+++ b/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
@@ -11,6 +11,12 @@ class ManifestUpdater {
   }
 
   def update(applicationName, manifestName, credentialsId, version) {
+    script.ws("/tmp/manifest_update") {
+      updateInsideNewWorkSpace(applicationName, manifestName, credentialsId, version)
+    }
+  }
+
+  def updateInsideNewWorkSpace(applicationName, manifestName, credentialsId, version) {
     checkoutCares(credentialsId)
     updateManifestFile(applicationName, manifestName, version)
     script.sshagent(credentials: [credentialsId]) { commitVersionInCares(applicationName, version) }

--- a/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
+++ b/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
@@ -9,6 +9,8 @@ class ManifestUpdaterSpecification extends Specification {
 
     def sh(hash) { }
 
+    def ws(filePath, closure) { }
+
     def git(hash) { }
 
     def readYaml(hash) { }
@@ -18,13 +20,25 @@ class ManifestUpdaterSpecification extends Specification {
     def PipeLineScript() { }
   }
 
-  def "#update writes to the yaml file"() {
+  def "#update runs in a new workspace"() {
+    given: "a manifest updater"
+    def PipeLineScript pipeline = Mock(PipeLineScript)
+    def manifestUpdater = new ManifestUpdater(pipeline)
+
+    when: "updating integration in cans"
+    manifestUpdater.update("dashboard", "preint", "cr-01", "1.3.0")
+
+    then:
+    1 * pipeline.ws("/tmp/manifest_update", _ as Closure)
+  }
+
+  def "#updateInsideNewWorkSpace writes to the yaml file"() {
     given: "a manifest updater"
     def PipeLineScript pipeline = Mock(PipeLineScript)
     def manifestUpdater = new ManifestUpdater(pipeline)
 
     when: "updating dashboard in preint"
-    manifestUpdater.update("dashboard", "preint", "cr-01", "1.3.0")
+    manifestUpdater.updateInsideNewWorkSpace("dashboard", "preint", "cr-01", "1.3.0")
 
     then: "it updates the file and commits the change"
     1 * pipeline.git([branch: "master", credentialsId: "cr-01", url: "git@github.com:ca-cwds/cws-cares.git"])

--- a/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
+++ b/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
@@ -26,9 +26,9 @@ class ManifestUpdaterSpecification extends Specification {
     def manifestUpdater = new ManifestUpdater(pipeline)
 
     when: "updating integration in cans"
-    manifestUpdater.update("dashboard", "preint", "cr-01", "1.3.0")
+    manifestUpdater.update("cans", "integration", "cr-01", "2.3.0")
 
-    then:
+    then: "it creates a new workspace"
     1 * pipeline.ws("/tmp/manifest_update", _ as Closure)
   }
 


### PR DESCRIPTION
So it turns out that sometimes projects expect to be in their checkout out code after the updateManifest runs, so this pushes it to a new temporary workspace to fix this.