### PR TITLE
DS-1830: Removes dependency on hardcoded workspace for checking out CARES

### DIFF
--- a/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
+++ b/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
@@ -11,7 +11,7 @@ class ManifestUpdater {
   }
 
   def update(applicationName, manifestName, credentialsId, version) {
-    script.ws("/tmp/manifest_update") {
+    script.ws {
       updateInsideNewWorkSpace(applicationName, manifestName, credentialsId, version)
     }
   }

--- a/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
+++ b/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
@@ -9,7 +9,7 @@ class ManifestUpdaterSpecification extends Specification {
 
     def sh(hash) { }
 
-    def ws(filePath, closure) { }
+    def ws(closure) { }
 
     def git(hash) { }
 
@@ -29,7 +29,7 @@ class ManifestUpdaterSpecification extends Specification {
     manifestUpdater.update("cans", "integration", "cr-01", "2.3.0")
 
     then: "it creates a new workspace"
-    1 * pipeline.ws("/tmp/manifest_update", _ as Closure)
+    1 * pipeline.ws(_ as Closure)
   }
 
   def "#updateInsideNewWorkSpace writes to the yaml file"() {


### PR DESCRIPTION
Tested on dashboard and it appears to work fine.