### PR TITLE
FIT-248: Covers use case of new untracked files when updating manifest

### DIFF
--- a/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
+++ b/src/gov/ca/cwds/jenkins/ManifestUpdater.groovy
@@ -23,7 +23,7 @@ class ManifestUpdater {
   }
 
   def commitVersionInCares(applicationName, version, manifestName) {
-    if (script.sh(script: "git status --porcelain", returnStdout: true)) {
+    if (script.sh(script: "git status --porcelain --untracked-files=no", returnStdout: true)) {
       script.sh(script: "git config --global user.email ${GIT_EMAIL}")
       script.sh(script: "git config --global user.name '${GIT_USER}'")
       script.sh(script: "git commit -am \"Update ${applicationName} to ${version} from Jenkins on ${manifestName} :octocat:\"")

--- a/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
+++ b/test/gov/ca/cwds/jenkins/ManifestUpdaterSpecification.groovy
@@ -57,7 +57,7 @@ class ManifestUpdaterSpecification extends Specification {
     manifestUpdater.commitVersionInCares("dashboard", "1.3.0", "preint")
 
     then: "it commits as the Jenkins user"
-    1 * pipeline.sh([script: "git status --porcelain", returnStdout: true]) >> "?? Readme.md"
+    1 * pipeline.sh([script: "git status --porcelain --untracked-files=no", returnStdout: true]) >> "M preint.yml"
     1 * pipeline.sh([script: "git config --global user.email cwdsdoeteam@osi.ca.gov"])
     1 * pipeline.sh([script: "git config --global user.name 'Jenkins'"])
     1 * pipeline.sh([script: "git commit -am \"Update dashboard to 1.3.0 from Jenkins on preint :octocat:\""])
@@ -73,7 +73,7 @@ class ManifestUpdaterSpecification extends Specification {
     manifestUpdater.commitVersionInCares("dashboard", "1.2.4", "preint")
 
     then: "it noops"
-    1 * pipeline.sh([script: "git status --porcelain", returnStdout: true]) >> null
+    1 * pipeline.sh([script: "git status --porcelain --untracked-files=no", returnStdout: true]) >> null
     0 * pipeline.sh(_)
   }
 }


### PR DESCRIPTION
Due to an issue uncovered where Jenkins is adding a retry file of it's own so
you don't get a clean status anymore.